### PR TITLE
Use singular Retrosheet in docs and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ file.upload.temp-dir=/tmp
 
 ## Roadmap
 
-- Add support for actual stats imported from Retrosheets.
+- Add support for actual stats imported from Retrosheet.
 - Implement data visualization features.
 - Add core statistics calculations (e.g. OBP, SLG, AVG, and a few custom ones like "Hitting Average", which is OBP minus walks.)
 - Implement advanced filtering and analytics tools.

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -8,7 +8,7 @@
                 <div class="col l6 s12">
                     <h5 class="white-text">Stats Visualizer</h5>
                     <p class="grey-text text-lighten-4">&copy; 2025 dojonate. All rights reserved. Data courtesy
-                        Retrosheets.</p>
+                        Retrosheet.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Standardize Retrosheet reference to singular form in README and footer fragment

## Testing
- `rg -i Retrosheets`
- `./gradlew test` *(fails: ParameterResolutionException / BeanCreationException)*

------
https://chatgpt.com/codex/tasks/task_e_689555eb6fb883288da2bd99459207e0