### PR TITLE
Add Retrosheet event file parser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'java'
     id("org.jetbrains.kotlin.jvm") version '1.9.10'
@@ -9,15 +11,9 @@ group = 'com.dojonate'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
-
-kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+    // Compile against Java 17 for cross-version compatibility
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.test {
@@ -45,6 +41,9 @@ dependencies {
 }
 
 kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
     sourceSets {
         test {
             kotlin.srcDir("src/test/kotlin") // Modern way to add Kotlin sources

--- a/src/main/java/com/dojonate/statsvisualizer/model/LineupEntry.java
+++ b/src/main/java/com/dojonate/statsvisualizer/model/LineupEntry.java
@@ -1,0 +1,7 @@
+package com.dojonate.statsvisualizer.model;
+
+/**
+ * Represents a starting lineup slot linking a player to a batting order and fielding position.
+ */
+public record LineupEntry(Player player, int battingOrder, int fieldingPosition) {
+}

--- a/src/main/java/com/dojonate/statsvisualizer/model/Play.java
+++ b/src/main/java/com/dojonate/statsvisualizer/model/Play.java
@@ -1,0 +1,18 @@
+package com.dojonate.statsvisualizer.model;
+
+/**
+ * Immutable representation of a single play from a Retrosheet event file.
+ */
+public record Play(
+        int inning,
+        boolean homeTeam,
+        String playerId,
+        String count,
+        String pitches,
+        String event
+) {
+    // Retain a conventional Java bean-style accessor for boolean property
+    public boolean isHomeTeam() {
+        return homeTeam;
+    }
+}

--- a/src/main/java/com/dojonate/statsvisualizer/model/Play.java
+++ b/src/main/java/com/dojonate/statsvisualizer/model/Play.java
@@ -1,5 +1,7 @@
 package com.dojonate.statsvisualizer.model;
 
+import java.util.Map;
+
 /**
  * Immutable representation of a single play from a Retrosheet event file.
  */
@@ -9,8 +11,13 @@ public record Play(
         String playerId,
         String count,
         String pitches,
-        String event
+        String event,
+        Map<Character, String> runnerAdvances
 ) {
+    public Play {
+        runnerAdvances = runnerAdvances == null ? Map.of() : Map.copyOf(runnerAdvances);
+    }
+
     // Retain a conventional Java bean-style accessor for boolean property
     public boolean isHomeTeam() {
         return homeTeam;

--- a/src/main/java/com/dojonate/statsvisualizer/model/RetrosheetGame.java
+++ b/src/main/java/com/dojonate/statsvisualizer/model/RetrosheetGame.java
@@ -1,0 +1,36 @@
+package com.dojonate.statsvisualizer.model;
+
+import java.util.*;
+
+/**
+ * Represents a single game parsed from a Retrosheet event file.
+ */
+public class RetrosheetGame {
+    private String gameId;
+    private final Map<String, String> info = new LinkedHashMap<>();
+    private final List<Play> plays = new ArrayList<>();
+
+    public String getGameId() {
+        return gameId;
+    }
+
+    public void setGameId(String gameId) {
+        this.gameId = gameId;
+    }
+
+    public Map<String, String> getInfo() {
+        return Collections.unmodifiableMap(info);
+    }
+
+    public List<Play> getPlays() {
+        return Collections.unmodifiableList(plays);
+    }
+
+    public void addInfo(String key, String value) {
+        info.put(key, value);
+    }
+
+    public void addPlay(Play play) {
+        plays.add(play);
+    }
+}

--- a/src/main/java/com/dojonate/statsvisualizer/model/RetrosheetGame.java
+++ b/src/main/java/com/dojonate/statsvisualizer/model/RetrosheetGame.java
@@ -9,6 +9,8 @@ public class RetrosheetGame {
     private String gameId;
     private final Map<String, String> info = new LinkedHashMap<>();
     private final List<Play> plays = new ArrayList<>();
+    private final List<LineupEntry> visitorLineup = new ArrayList<>();
+    private final List<LineupEntry> homeLineup = new ArrayList<>();
 
     public String getGameId() {
         return gameId;
@@ -26,11 +28,23 @@ public class RetrosheetGame {
         return Collections.unmodifiableList(plays);
     }
 
+    public List<LineupEntry> getVisitorLineup() {
+        return Collections.unmodifiableList(visitorLineup);
+    }
+
+    public List<LineupEntry> getHomeLineup() {
+        return Collections.unmodifiableList(homeLineup);
+    }
+
     public void addInfo(String key, String value) {
         info.put(key, value);
     }
 
     public void addPlay(Play play) {
         plays.add(play);
+    }
+
+    public void addLineupEntry(boolean home, LineupEntry entry) {
+        (home ? homeLineup : visitorLineup).add(entry);
     }
 }

--- a/src/main/java/com/dojonate/statsvisualizer/model/RetrosheetGame.java
+++ b/src/main/java/com/dojonate/statsvisualizer/model/RetrosheetGame.java
@@ -11,6 +11,8 @@ public class RetrosheetGame {
     private final List<Play> plays = new ArrayList<>();
     private final List<LineupEntry> visitorLineup = new ArrayList<>();
     private final List<LineupEntry> homeLineup = new ArrayList<>();
+    private final List<Substitution> visitorSubstitutions = new ArrayList<>();
+    private final List<Substitution> homeSubstitutions = new ArrayList<>();
 
     public String getGameId() {
         return gameId;
@@ -36,6 +38,14 @@ public class RetrosheetGame {
         return Collections.unmodifiableList(homeLineup);
     }
 
+    public List<Substitution> getVisitorSubstitutions() {
+        return Collections.unmodifiableList(visitorSubstitutions);
+    }
+
+    public List<Substitution> getHomeSubstitutions() {
+        return Collections.unmodifiableList(homeSubstitutions);
+    }
+
     public void addInfo(String key, String value) {
         info.put(key, value);
     }
@@ -46,5 +56,9 @@ public class RetrosheetGame {
 
     public void addLineupEntry(boolean home, LineupEntry entry) {
         (home ? homeLineup : visitorLineup).add(entry);
+    }
+
+    public void addSubstitution(boolean home, Substitution substitution) {
+        (home ? homeSubstitutions : visitorSubstitutions).add(substitution);
     }
 }

--- a/src/main/java/com/dojonate/statsvisualizer/model/Substitution.java
+++ b/src/main/java/com/dojonate/statsvisualizer/model/Substitution.java
@@ -1,0 +1,13 @@
+package com.dojonate.statsvisualizer.model;
+
+/**
+ * Represents a lineup change or substitution occurring during a game.
+ */
+public record Substitution(
+        Player playerIn,
+        Player playerOut,
+        int battingOrder,
+        int fieldingPosition,
+        int inning,
+        boolean homeHalf
+) {}

--- a/src/main/java/com/dojonate/statsvisualizer/util/RetrosheetEventParser.java
+++ b/src/main/java/com/dojonate/statsvisualizer/util/RetrosheetEventParser.java
@@ -1,0 +1,73 @@
+package com.dojonate.statsvisualizer.util;
+
+import com.dojonate.statsvisualizer.model.Play;
+import com.dojonate.statsvisualizer.model.RetrosheetGame;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Parser for Retrosheet event files (*.EVN, *.EVA, etc.).
+ * It extracts the game id, info lines and every play from the file.
+ */
+@Component
+public class RetrosheetEventParser {
+
+    /**
+     * Parses a Retrosheet event file into a {@link RetrosheetGame} representation.
+     *
+     * @param filePath path to the event file
+     * @return parsed game
+     * @throws IOException if an IO error occurs
+     */
+    public RetrosheetGame parseEventFile(Path filePath) throws IOException {
+        RetrosheetGame game = new RetrosheetGame();
+
+        try (BufferedReader reader = Files.newBufferedReader(filePath)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String trimmed = line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                    continue; // ignore comments and blank lines
+                }
+
+                if (trimmed.startsWith("id,")) {
+                    game.setGameId(trimmed.substring(3));
+                } else if (trimmed.startsWith("info,")) {
+                    String[] parts = trimmed.split(",", 3);
+                    if (parts.length == 3) {
+                        game.addInfo(parts[1], parts[2]);
+                    }
+                } else if (trimmed.startsWith("play,")) {
+                    parsePlayLine(trimmed).ifPresent(game::addPlay);
+                }
+            }
+        }
+
+        return game;
+    }
+
+    private Optional<Play> parsePlayLine(String line) {
+        // play,inning,home/visitor,playerID,count,pitches,event
+        String[] parts = line.split(",", 7);
+        if (parts.length < 7) {
+            return Optional.empty();
+        }
+
+        try {
+            int inning = Integer.parseInt(parts[1]);
+            boolean home = "1".equals(parts[2]);
+            String playerId = parts[3];
+            String count = parts[4];
+            String pitches = parts[5];
+            String event = parts[6];
+            return Optional.of(new Play(inning, home, playerId, count, pitches, event));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/dojonate/statsvisualizer/util/RetrosheetEventParser.java
+++ b/src/main/java/com/dojonate/statsvisualizer/util/RetrosheetEventParser.java
@@ -1,6 +1,9 @@
 package com.dojonate.statsvisualizer.util;
 
+import com.dojonate.statsvisualizer.model.LineupEntry;
 import com.dojonate.statsvisualizer.model.Play;
+import com.dojonate.statsvisualizer.model.Player;
+import com.dojonate.statsvisualizer.model.RosterEntry;
 import com.dojonate.statsvisualizer.model.RetrosheetGame;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -27,6 +31,18 @@ public class RetrosheetEventParser {
      * @throws IOException if an IO error occurs
      */
     public RetrosheetGame parseEventFile(Path filePath) throws IOException {
+        return parseEventFile(filePath, Map.of());
+    }
+
+    /**
+     * Parses a Retrosheet event file with optional roster data for cross-referencing starting lineups.
+     *
+     * @param filePath path to the event file
+     * @param rostersByTeam map of team id to roster entries
+     * @return parsed game
+     * @throws IOException if an IO error occurs
+     */
+    public RetrosheetGame parseEventFile(Path filePath, Map<String, List<RosterEntry>> rostersByTeam) throws IOException {
         RetrosheetGame game = new RetrosheetGame();
 
         try (BufferedReader reader = Files.newBufferedReader(filePath)) {
@@ -44,6 +60,8 @@ public class RetrosheetEventParser {
                     if (parts.length == 3) {
                         game.addInfo(parts[1], parts[2]);
                     }
+                } else if (trimmed.startsWith("start,")) {
+                    parseStartLine(trimmed, game, rostersByTeam);
                 } else if (trimmed.startsWith("play,")) {
                     parsePlayLine(trimmed).ifPresent(game::addPlay);
                 }
@@ -98,5 +116,57 @@ public class RetrosheetEventParser {
             }
         }
         return advances;
+    }
+
+    private void parseStartLine(String line, RetrosheetGame game, Map<String, List<RosterEntry>> rostersByTeam) {
+        // start,playerID,"Player Name",home/visitor,battingPos,fieldPos
+        String[] parts = line.split(",", 6);
+        if (parts.length < 6) {
+            return;
+        }
+        String playerId = parts[1];
+        String rawName = parts[2];
+        if (rawName.startsWith("\"") && rawName.endsWith("\"")) {
+            rawName = rawName.substring(1, rawName.length() - 1);
+        }
+        boolean home = "1".equals(parts[3]);
+        try {
+            int battingOrder = Integer.parseInt(parts[4]);
+            int fieldPos = Integer.parseInt(parts[5]);
+
+            Player player = findPlayerFromRoster(game, rostersByTeam, playerId, home);
+            if (player == null) {
+                player = createFallbackPlayer(playerId, rawName);
+            }
+            game.addLineupEntry(home, new LineupEntry(player, battingOrder, fieldPos));
+        } catch (NumberFormatException ignored) {
+            // ignore invalid start line
+        }
+    }
+
+    private Player findPlayerFromRoster(RetrosheetGame game, Map<String, List<RosterEntry>> rostersByTeam, String playerId, boolean home) {
+        String teamKey = game.getInfo().get(home ? "hometeam" : "visteam");
+        List<RosterEntry> roster = rostersByTeam.get(teamKey);
+        if (roster != null) {
+            for (RosterEntry entry : roster) {
+                if (entry.getPlayer().getPlayerId().equals(playerId)) {
+                    return entry.getPlayer();
+                }
+            }
+        }
+        return null;
+    }
+
+    private Player createFallbackPlayer(String playerId, String name) {
+        Player player = new Player();
+        player.setPlayerId(playerId);
+        String[] tokens = name.trim().split(" ");
+        if (tokens.length > 0) {
+            player.setFirstName(tokens[0]);
+            if (tokens.length > 1) {
+                player.setLastName(tokens[tokens.length - 1]);
+            }
+        }
+        return player;
     }
 }

--- a/src/main/java/com/dojonate/statsvisualizer/util/RetrosheetEventParser.java
+++ b/src/main/java/com/dojonate/statsvisualizer/util/RetrosheetEventParser.java
@@ -8,6 +8,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -64,10 +66,37 @@ public class RetrosheetEventParser {
             String playerId = parts[3];
             String count = parts[4];
             String pitches = parts[5];
-            String event = parts[6];
-            return Optional.of(new Play(inning, home, playerId, count, pitches, event));
+            String eventField = parts[6];
+            int dotIndex = eventField.indexOf('.');
+            String event = dotIndex >= 0 ? eventField.substring(0, dotIndex) : eventField;
+            Map<Character, String> advances = dotIndex >= 0
+                    ? parseRunnerAdvances(eventField.substring(dotIndex + 1))
+                    : Map.of();
+            return Optional.of(new Play(inning, home, playerId, count, pitches, event, advances));
         } catch (NumberFormatException ex) {
             return Optional.empty();
         }
+    }
+
+    private Map<Character, String> parseRunnerAdvances(String advancePart) {
+        Map<Character, String> advances = new LinkedHashMap<>();
+        if (advancePart == null || advancePart.isEmpty()) {
+            return advances;
+        }
+        String[] tokens = advancePart.split(";");
+        for (String token : tokens) {
+            String trimmed = token.trim();
+            if (trimmed.length() >= 3) {
+                char from = trimmed.charAt(0);
+                char action = trimmed.charAt(1);
+                char to = trimmed.charAt(2);
+                if (action == '-') {
+                    advances.put(from, String.valueOf(to));
+                } else if (action == 'X') {
+                    advances.put(from, "X" + to);
+                }
+            }
+        }
+        return advances;
     }
 }

--- a/src/main/java/com/dojonate/statsvisualizer/util/RetrosheetEventParser.java
+++ b/src/main/java/com/dojonate/statsvisualizer/util/RetrosheetEventParser.java
@@ -5,6 +5,7 @@ import com.dojonate.statsvisualizer.model.Play;
 import com.dojonate.statsvisualizer.model.Player;
 import com.dojonate.statsvisualizer.model.RosterEntry;
 import com.dojonate.statsvisualizer.model.RetrosheetGame;
+import com.dojonate.statsvisualizer.model.Substitution;
 import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
@@ -47,6 +48,10 @@ public class RetrosheetEventParser {
 
         try (BufferedReader reader = Files.newBufferedReader(filePath)) {
             String line;
+            int currentInning = 0;
+            boolean currentHalf = false;
+            Map<Integer, Player> visitorLineup = new LinkedHashMap<>();
+            Map<Integer, Player> homeLineup = new LinkedHashMap<>();
             while ((line = reader.readLine()) != null) {
                 String trimmed = line.trim();
                 if (trimmed.isEmpty() || trimmed.startsWith("#")) {
@@ -61,9 +66,17 @@ public class RetrosheetEventParser {
                         game.addInfo(parts[1], parts[2]);
                     }
                 } else if (trimmed.startsWith("start,")) {
-                    parseStartLine(trimmed, game, rostersByTeam);
+                    parseStartLine(trimmed, game, rostersByTeam, visitorLineup, homeLineup);
+                } else if (trimmed.startsWith("sub,")) {
+                    parseSubLine(trimmed, game, rostersByTeam, visitorLineup, homeLineup, currentInning, currentHalf);
                 } else if (trimmed.startsWith("play,")) {
-                    parsePlayLine(trimmed).ifPresent(game::addPlay);
+                    Optional<Play> maybePlay = parsePlayLine(trimmed);
+                    if (maybePlay.isPresent()) {
+                        Play play = maybePlay.get();
+                        game.addPlay(play);
+                        currentInning = play.inning();
+                        currentHalf = play.isHomeTeam();
+                    }
                 }
             }
         }
@@ -118,7 +131,8 @@ public class RetrosheetEventParser {
         return advances;
     }
 
-    private void parseStartLine(String line, RetrosheetGame game, Map<String, List<RosterEntry>> rostersByTeam) {
+    private void parseStartLine(String line, RetrosheetGame game, Map<String, List<RosterEntry>> rostersByTeam,
+                               Map<Integer, Player> visitorLineup, Map<Integer, Player> homeLineup) {
         // start,playerID,"Player Name",home/visitor,battingPos,fieldPos
         String[] parts = line.split(",", 6);
         if (parts.length < 6) {
@@ -139,8 +153,41 @@ public class RetrosheetEventParser {
                 player = createFallbackPlayer(playerId, rawName);
             }
             game.addLineupEntry(home, new LineupEntry(player, battingOrder, fieldPos));
+            (home ? homeLineup : visitorLineup).put(battingOrder, player);
         } catch (NumberFormatException ignored) {
             // ignore invalid start line
+        }
+    }
+
+    private void parseSubLine(String line, RetrosheetGame game, Map<String, List<RosterEntry>> rostersByTeam,
+                              Map<Integer, Player> visitorLineup, Map<Integer, Player> homeLineup,
+                              int currentInning, boolean currentHalf) {
+        // sub,playerID,"Player Name",home/visitor,battingPos,fieldPos
+        String[] parts = line.split(",", 6);
+        if (parts.length < 6) {
+            return;
+        }
+        String playerId = parts[1];
+        String rawName = parts[2];
+        if (rawName.startsWith("\"") && rawName.endsWith("\"")) {
+            rawName = rawName.substring(1, rawName.length() - 1);
+        }
+        boolean home = "1".equals(parts[3]);
+        try {
+            int battingOrder = Integer.parseInt(parts[4]);
+            int fieldPos = Integer.parseInt(parts[5]);
+
+            Player player = findPlayerFromRoster(game, rostersByTeam, playerId, home);
+            if (player == null) {
+                player = createFallbackPlayer(playerId, rawName);
+            }
+            Map<Integer, Player> lineup = home ? homeLineup : visitorLineup;
+            Player replaced = lineup.get(battingOrder);
+            Substitution sub = new Substitution(player, replaced, battingOrder, fieldPos, currentInning, currentHalf);
+            game.addSubstitution(home, sub);
+            lineup.put(battingOrder, player);
+        } catch (NumberFormatException ignored) {
+            // ignore invalid substitution line
         }
     }
 

--- a/src/test/kotlin/com/dojonate/statsvisualizer/StatsVisualizerApplicationTests.kt
+++ b/src/test/kotlin/com/dojonate/statsvisualizer/StatsVisualizerApplicationTests.kt
@@ -2,8 +2,10 @@ package com.dojonate.statsvisualizer
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest
+@ActiveProfiles("test")
 class StatsVisualizerApplicationTests {
 
     @Test

--- a/src/test/kotlin/com/dojonate/statsvisualizer/util/RetrosheetEventParserTest.kt
+++ b/src/test/kotlin/com/dojonate/statsvisualizer/util/RetrosheetEventParserTest.kt
@@ -1,0 +1,72 @@
+package com.dojonate.statsvisualizer.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
+
+class RetrosheetEventParserTest {
+
+    private val parser = RetrosheetEventParser()
+
+    @Test
+    fun `should parse event file with plays`() {
+        val content = """
+            id,EXAMPLE1
+            info,visteam,HOU
+            info,hometeam,TEX
+            play,1,0,aloma001,??,S,S7/G
+            play,1,1,adamm001,??,X,HR/7
+        """.trimIndent()
+
+        val tempFile = createTempFile("example.evn", content)
+
+        val game = parser.parseEventFile(tempFile)
+
+        assertEquals("EXAMPLE1", game.gameId)
+        assertEquals("HOU", game.info["visteam"])
+        assertEquals(2, game.plays.size)
+        assertEquals(1, game.plays[0].inning)
+        assertEquals(false, game.plays[0].isHomeTeam())
+        assertEquals("aloma001", game.plays[0].playerId)
+        assertEquals("HR/7", game.plays[1].event)
+    }
+
+    @Test
+    fun `should parse sample Retrosheet file`() {
+        val resource = javaClass.getResource("/retrosheet/BOS19300415.EVA")!!
+        val path = Paths.get(resource.toURI())
+
+        val game = parser.parseEventFile(path)
+
+        assertEquals("BOS193004150", game.gameId)
+        assertEquals("WS1", game.info["visteam"])
+        assertEquals(75, game.plays.size)
+        assertEquals("wests101", game.plays.first().playerId)
+        assertEquals("E5/G", game.plays.first().event)
+    }
+
+    @Test
+    fun `should ignore comments and blank lines`() {
+        val content = """
+            id,EXAMPLE2
+
+            # comment line
+            play,1,0,aloma001,??,S,S7/G
+        """.trimIndent()
+
+        val tempFile = createTempFile("example2.evn", content)
+        val game = parser.parseEventFile(tempFile)
+
+        assertEquals(1, game.plays.size)
+        assertEquals("aloma001", game.plays.first().playerId)
+    }
+
+    private fun createTempFile(fileName: String, content: String): Path {
+        val tempFile = Files.createTempFile(fileName, fileName)
+        Files.write(tempFile, content.toByteArray(), StandardOpenOption.WRITE)
+        return tempFile
+    }
+}

--- a/src/test/kotlin/com/dojonate/statsvisualizer/util/RetrosheetEventParserTest.kt
+++ b/src/test/kotlin/com/dojonate/statsvisualizer/util/RetrosheetEventParserTest.kt
@@ -64,6 +64,23 @@ class RetrosheetEventParserTest {
         assertEquals("aloma001", game.plays.first().playerId)
     }
 
+    @Test
+    fun `should parse runner advances`() {
+        val content = """
+            id,EXAMPLE3
+            play,1,0,aloma001,??,S,S7/G.1-2;B-1
+            play,1,0,smith001,??,S,S7/G.1X2
+        """.trimIndent()
+
+        val tempFile = createTempFile("example3.evn", content)
+        val game = parser.parseEventFile(tempFile)
+
+        assertEquals("2", game.plays[0].runnerAdvances['1'])
+        assertEquals("1", game.plays[0].runnerAdvances['B'])
+        assertEquals("X2", game.plays[1].runnerAdvances['1'])
+        assertEquals("S7/G", game.plays[0].event)
+    }
+
     private fun createTempFile(fileName: String, content: String): Path {
         val tempFile = Files.createTempFile(fileName, fileName)
         Files.write(tempFile, content.toByteArray(), StandardOpenOption.WRITE)

--- a/src/test/kotlin/com/dojonate/statsvisualizer/util/RetrosheetEventParserTest.kt
+++ b/src/test/kotlin/com/dojonate/statsvisualizer/util/RetrosheetEventParserTest.kt
@@ -1,6 +1,9 @@
 package com.dojonate.statsvisualizer.util
 
+import com.dojonate.statsvisualizer.model.Team
+import com.dojonate.statsvisualizer.util.RosFileParser
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
@@ -79,6 +82,34 @@ class RetrosheetEventParserTest {
         assertEquals("1", game.plays[0].runnerAdvances['B'])
         assertEquals("X2", game.plays[1].runnerAdvances['1'])
         assertEquals("S7/G", game.plays[0].event)
+    }
+
+    @Test
+    fun `should parse starting lineups with roster cross reference`() {
+        val event = Paths.get(javaClass.getResource("/retrosheet/BOS19300415.EVA")!!.toURI())
+        val bosTeam = Team("BOS", "Boston Red Sox", "AL", null, null)
+        val wsTeam = Team("WS1", "Washington Senators", "AL", null, null)
+        val rosParser = RosFileParser()
+        val bosRoster = rosParser.parseRosFile(Paths.get(javaClass.getResource("/retrosheet/BOS1930.ROS")!!.toURI()), bosTeam)
+        val wsRoster = rosParser.parseRosFile(Paths.get(javaClass.getResource("/retrosheet/WS11930.ROS")!!.toURI()), wsTeam)
+        val rosters = mapOf("BOS" to bosRoster, "WS1" to wsRoster)
+
+        val game = parser.parseEventFile(event, rosters)
+
+        assertEquals(9, game.visitorLineup.size)
+        assertEquals(9, game.homeLineup.size)
+
+        val westRosterPlayer = wsRoster.first { it.player.playerId == "wests101" }.player
+        val westLineup = game.visitorLineup.first()
+        assertSame(westRosterPlayer, westLineup.player)
+        assertEquals(1, westLineup.battingOrder)
+        assertEquals(8, westLineup.fieldingPosition)
+
+        val rothRosterPlayer = bosRoster.first { it.player.playerId == "rothj101" }.player
+        val rothLineup = game.homeLineup.first()
+        assertSame(rothRosterPlayer, rothLineup.player)
+        assertEquals(1, rothLineup.battingOrder)
+        assertEquals(9, rothLineup.fieldingPosition)
     }
 
     private fun createTempFile(fileName: String, content: String): Path {

--- a/src/test/kotlin/com/dojonate/statsvisualizer/util/RetrosheetEventParserTest.kt
+++ b/src/test/kotlin/com/dojonate/statsvisualizer/util/RetrosheetEventParserTest.kt
@@ -112,6 +112,35 @@ class RetrosheetEventParserTest {
         assertEquals(9, rothLineup.fieldingPosition)
     }
 
+    @Test
+    fun `should parse substitutions`() {
+        val event = Paths.get(javaClass.getResource("/retrosheet/BOS19300415.EVA")!!.toURI())
+        val bosTeam = Team("BOS", "Boston Red Sox", "AL", null, null)
+        val wsTeam = Team("WS1", "Washington Senators", "AL", null, null)
+        val rosParser = RosFileParser()
+        val bosRoster = rosParser.parseRosFile(Paths.get(javaClass.getResource("/retrosheet/BOS1930.ROS")!!.toURI()), bosTeam)
+        val wsRoster = rosParser.parseRosFile(Paths.get(javaClass.getResource("/retrosheet/WS11930.ROS")!!.toURI()), wsTeam)
+        val rosters = mapOf("BOS" to bosRoster, "WS1" to wsRoster)
+
+        val game = parser.parseEventFile(event, rosters)
+
+        assertEquals(4, game.homeSubstitutions.size)
+        val firstSub = game.homeSubstitutions.first()
+        assertEquals("cicej101", firstSub.playerIn().playerId)
+        val berry = bosRoster.first { it.player.playerId == "berrc103" }.player
+        assertSame(berry, firstSub.playerOut())
+        assertEquals(8, firstSub.battingOrder())
+        assertEquals(11, firstSub.fieldingPosition())
+        assertEquals(8, firstSub.inning())
+        assertEquals(true, firstSub.homeHalf())
+
+        val secondSub = game.homeSubstitutions[1]
+        assertEquals(false, secondSub.homeHalf())
+        assertEquals(9, secondSub.inning())
+        assertEquals("conne101", secondSub.playerIn().playerId)
+        assertEquals("cicej101", secondSub.playerOut()?.playerId)
+    }
+
     private fun createTempFile(fileName: String, content: String): Path {
         val tempFile = Files.createTempFile(fileName, fileName)
         Files.write(tempFile, content.toByteArray(), StandardOpenOption.WRITE)

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -3,3 +3,6 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=maintainer
 spring.datasource.password=password
 spring.jpa.hibernate.ddl-auto=create-drop
+
+file.upload.temp-dir=./build/tmp
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect

--- a/src/test/resources/retrosheet/BOS1930.ROS
+++ b/src/test/resources/retrosheet/BOS1930.ROS
@@ -1,0 +1,9 @@
+rothj101,Rothrock,Jack,S,R,BOS,RF
+millo102,Miller,Otto,R,R,BOS,3B
+olivt101,Oliver,Tom,R,R,BOS,CF
+scarr103,Scarritt,Russ,L,L,BOS,LF
+regab101,Regan,Bill,R,R,BOS,2B
+sweeb101,Sweeney,Bill,R,R,BOS,1B
+narlb101,Narleski,Bill,R,R,BOS,SS
+berrc103,Berry,Charlie,R,R,BOS,C
+ruffr101,Ruffing,Red,R,R,BOS,P

--- a/src/test/resources/retrosheet/BOS19300415.EVA
+++ b/src/test/resources/retrosheet/BOS19300415.EVA
@@ -1,0 +1,133 @@
+id,BOS193004150
+version,2
+info,inputprogvers,"version 7RS(19) of 07/07/92"
+info,visteam,WS1
+info,hometeam,BOS
+info,date,1930/04/15
+info,site,BOS07
+info,number,0
+info,starttime,0:00PM
+info,daynight,day
+info,usedh,false
+info,translator,"Dick Cramer"
+info,inputter,"Dick Cramer"
+info,inputtime,2020/01/29 11:00AM
+info,scorer,"71,163,274,222"
+info,umphome,owenb901
+info,ump1b,morig101
+info,ump2b,(none)
+info,ump3b,campb901
+info,howscored,unknown
+info,pitches,none
+info,temp,0
+info,winddir,unknown
+info,windspeed,-1
+info,fieldcond,unknown
+info,precip,unknown
+info,timeofgame,98
+info,attendance,7500
+info,sky,unknown
+info,wp,browl101
+info,lp,ruffr101
+info,save,
+info,gwrbi,
+start,wests101,"Sam West",0,1,8
+start,rices101,"Sam Rice",0,2,9
+start,goslg101,"Goose Goslin",0,3,7
+start,myerb103,"Buddy Myer",0,4,4
+start,cronj101,"Joe Cronin",0,5,6
+start,judgj101,"Joe Judge",0,6,3
+start,blueo102,"Ossie Bluege",0,7,5
+start,ruelm101,"Muddy Ruel",0,8,2
+start,browl101,"Lloyd Brown",0,9,1
+start,rothj101,"Jack Rothrock",1,1,9
+start,millo102,"Otto Miller",1,2,5
+start,olivt101,"Tom Oliver",1,3,8
+start,scarr103,"Russ Scarritt",1,4,7
+start,regab101,"Bill Regan",1,5,4
+start,sweeb101,"Bill Sweeney",1,6,3
+start,narlb101,"Bill Narleski",1,7,6
+start,berrc103,"Charlie Berry",1,8,2
+start,ruffr101,"Red Ruffing",1,9,1
+play,1,0,wests101,??,,E5/G
+play,1,0,rices101,??,,99/F
+play,1,0,goslg101,??,,S8/P.1X3(65)
+play,1,0,myerb103,??,,W.1-2
+play,1,0,cronj101,??,,HR/7.2-H;1-H
+play,1,0,judgj101,??,,K
+play,1,1,rothj101,??,,K
+play,1,1,millo102,??,,99
+play,1,1,olivt101,??,,99
+play,2,0,blueo102,??,,K
+play,2,0,ruelm101,??,,99
+play,2,0,browl101,??,,99
+play,2,1,scarr103,??,,S9
+play,2,1,regab101,??,,99
+play,2,1,sweeb101,??,,99
+play,2,1,narlb101,??,,99
+play,3,0,wests101,??,,S9
+play,3,0,rices101,??,,D9.1-H
+play,3,0,goslg101,??,,BK.2-3
+play,3,0,goslg101,??,,PB.3-H
+play,3,0,goslg101,??,,43
+play,3,0,myerb103,??,,43
+play,3,0,cronj101,??,,D7
+play,3,0,judgj101,??,,BK.2-3
+play,3,0,judgj101,??,,3/G
+play,3,1,berrc103,??,,W
+play,3,1,ruffr101,??,,99
+play,3,1,rothj101,??,,99
+play,3,1,millo102,??,,99
+play,4,0,blueo102,??,,S
+play,4,0,ruelm101,??,,S.1-2
+play,4,0,browl101,??,,99/SH.2-3;1-2
+play,4,0,wests101,??,,2/FL
+play,4,0,rices101,??,,6/F
+play,4,1,olivt101,??,,99
+play,4,1,scarr103,??,,99
+play,4,1,regab101,??,,99
+play,5,0,goslg101,??,,99
+play,5,0,myerb103,??,,99
+play,5,0,cronj101,??,,99
+play,5,1,sweeb101,??,,99
+play,5,1,narlb101,??,,99
+play,5,1,berrc103,??,,99
+play,6,0,judgj101,??,,99
+play,6,0,blueo102,??,,99
+play,6,0,ruelm101,??,,99
+play,6,1,ruffr101,??,,D8
+play,6,1,rothj101,??,,9/P
+play,6,1,millo102,??,,S.2-H
+play,6,1,olivt101,??,,99
+play,6,1,scarr103,??,,99
+play,7,0,browl101,??,,99
+play,7,0,wests101,??,,99
+play,7,0,rices101,??,,S9.B-2(E9)
+play,7,0,goslg101,??,,K
+play,7,1,regab101,??,,99
+play,7,1,sweeb101,??,,99
+play,7,1,narlb101,??,,99
+play,8,0,myerb103,??,,T
+play,8,0,cronj101,??,,8/SF.3-H
+play,8,0,judgj101,??,,99
+play,8,0,blueo102,??,,99
+play,8,1,berrc103,??,,NP
+sub,cicej101,"Joe Cicero",1,8,11
+play,8,1,cicej101,??,,99
+play,8,1,ruffr101,??,,5/L
+play,8,1,rothj101,??,,99
+play,9,0,ruelm101,??,,NP
+sub,conne101,"Ed Connelly",1,8,2
+play,9,0,ruelm101,??,,NP
+sub,mulrf101,"F Mulrooney",1,9,1
+play,9,0,ruelm101,??,,K
+play,9,0,browl101,??,,99
+play,9,0,wests101,??,,99
+play,9,1,millo102,??,,99
+play,9,1,olivt101,??,,99
+play,9,1,scarr103,??,,NP
+sub,barrb105,"Bill Barrett",1,4,11
+play,9,1,barrb105,??,,99
+data,er,browl101,1
+data,er,ruffr101,6
+data,er,mulrf101,0

--- a/src/test/resources/retrosheet/WS11930.ROS
+++ b/src/test/resources/retrosheet/WS11930.ROS
@@ -1,0 +1,9 @@
+wests101,West,Sam,L,R,WS1,CF
+rices101,Rice,Sam,L,R,WS1,RF
+goslg101,Goslin,Goose,L,R,WS1,LF
+myerb103,Myer,Buddy,L,R,WS1,2B
+cronj101,Cronin,Joe,R,R,WS1,SS
+judgj101,Judge,Joe,L,L,WS1,1B
+blueo102,Bluege,Ossie,R,R,WS1,3B
+ruelm101,Ruel,Muddy,R,R,WS1,C
+browl101,Brown,Lloyd,R,L,WS1,P


### PR DESCRIPTION
## Summary
- use Java record for `Play` and expose `RetrosheetGame` data through unmodifiable collections
- harden `RetrosheetEventParser` by skipping comments/blank lines and avoiding `null` returns
- add regression tests for parsing and configure build for Java 17 compatibility

## Testing
- `bash gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689558a749288328ad51021d19347256